### PR TITLE
adding support for counters that are coming in 1.0 format

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -540,8 +540,15 @@ func parseLine(line []byte) *Packet {
 	case "c":
 		value, err = strconv.ParseInt(string(val), 10, 64)
 		if err != nil {
-			log.Printf("ERROR: failed to ParseInt %s - %s", string(val), err)
-			return nil
+			//try to strip ".0" if being sent that way (overops send it like that :( )
+			if (strings.HasSuffix(val, ".0")) {
+				value, err = strconv.ParseInt(strings.TrimSuffix(val,".0"), 10, 64)	
+			}
+			if (err != nil) {
+				log.Printf("ERROR: failed to ParseInt %s - %s", string(val), err)
+				return nil
+			}
+			
 		}
 		stattype = "counters."
 	case "g":


### PR DESCRIPTION
previously: ERROR: failed to ParseInt 1.0 - strconv.ParseInt: parsing "1.0": invalid syntax